### PR TITLE
Updated map.py and layergroup.py

### DIFF
--- a/docs/source/api-docs.rst
+++ b/docs/source/api-docs.rst
@@ -46,6 +46,7 @@ Methods
     * removeControl
     * removeLayer
     * setMaxBounds
+    * fitBounds
     * setMaxZoom
     * setMinZoom
     * setView
@@ -96,6 +97,7 @@ Methods
 ^^^^^^^
     * addLayer
     * removeLayer
+    * clearLayers
     * toGeoJSON
 
 L.featureGroup

--- a/pyqtlet/leaflet/layer/layergroup.py
+++ b/pyqtlet/leaflet/layer/layergroup.py
@@ -32,7 +32,12 @@ class LayerGroup(Layer):
         js = '{layerGroup}.removeLayer({layerName})'.format(layerGroup=self._layerName,
                 layerName=layer._layerName)
         self.runJavaScript(js)
-
+    
+    def clearLayers(self, layer):
+        js = '{layerGroup}.clearLayers({layerName})'.format(layerGroup=self._layerName,
+                layerName=layer._layerName)
+        self.runJavaScript(js)
+    
     def toGeoJSON(self, callback):
         self.getJsResponse('{layer}.toGeoJSON()'.format(layer=self.jsName), callback)
 

--- a/pyqtlet/leaflet/map/map.py
+++ b/pyqtlet/leaflet/map/map.py
@@ -158,6 +158,10 @@ class Map(Evented):
     def setMaxBounds(self, bounds):
         js = 'map.setMaxBounds({bounds})'.format(bounds=bounds)
         self.runJavaScript(js)
+       
+    def fitBounds(self, bounds):
+        js = 'map.fitBounds({bounds})'.format(bounds=bounds)
+        self.runJavaScript(js)
 
     def setMaxZoom(self, zoom):
         js = 'map.setMaxZoom({zoom})'.format(zoom=zoom)


### PR DESCRIPTION
- Added clearLayers() function to the map.py file to clear all the layers of the map a that instance.
- Added fitBounds() function to set a map view that contains the given geographical bounds with the maximum zoom level possible.